### PR TITLE
Add oathkeeper rock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+oathkeeper_*.rock
+.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Build and deploy
+
+```bash
+rockcraft pack -v
+sudo skopeo --insecure-policy copy oci-archive:oathkeeper_0.40.3_amd64.rock docker-daemon:oathkeeper:0.40.3
+docker run oathkeeper:0.40.3
+```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,28 @@
+name: oathkeeper
+base: bare
+build-base: ubuntu:22.04
+version: "0.40.3"
+summary: Ory Oathkeeper
+description: |
+  Ory Oathkeeper is a cloud native Identity & Access Proxy / API (IAP) and Access Control Decision API that authenticates, authorizes, and mutates incoming HTTP(s) requests.
+license: Apache-2.0
+platforms:
+  amd64:
+
+services:
+  oathkeeper:
+    override: replace
+    command: oathkeeper serve
+    startup: enabled
+
+parts:
+  oathkeeper:
+    plugin: go
+    build-snaps:
+      - go/1.20/stable
+    build-environment:
+      - GOFLAGS: -ldflags=-w -ldflags=-s
+      - CGO_ENABLED: 0
+    source: https://github.com/ory/oathkeeper
+    source-type: git
+    source-tag: v0.40.3


### PR DESCRIPTION
To test this PR, pack the image with rockcraft, save it in local registry and run a container:
```
rockcraft pack -v
skopeo --insecure-policy copy oci-archive:oathkeeper_0.40.3_amd64.rock docker-daemon:oathkeeper:0.40.3
docker run --rm -it oathkeeper:0.40.3
```

Inspect the container to retrieve its IP address, then try to reach its /health endpoint, for example
`curl http://172.17.0.2:4456/health/alive`. The response should be `{"status":"ok"}`