### PR TITLE
feat: provide version, git commit hash, and build time to the built oathkeeper binary

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -21,8 +21,20 @@ parts:
     build-snaps:
       - go/1.20/stable
     build-environment:
-      - GOFLAGS: -ldflags=-w -ldflags=-s
       - CGO_ENABLED: 0
+    override-build: |
+      src_config_path="github.com/ory/oathkeeper"
+      build_ver="${src_config_path}/x.Version"
+      build_hash="${src_config_path}/x.Commit"
+      build_date="${src_config_path}/x.Date"
+      go_linker_flags="-s \
+                       -w \
+                       -X ${build_ver}=$(git -C "${CRAFT_PART_SRC}" describe --tags) \
+                       -X ${build_hash}=$(git -C "${CRAFT_PART_SRC}" rev-parse HEAD) \
+                       -X ${build_date}=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      go mod download
+      go build -ldflags="${go_linker_flags}" -o ${CRAFT_PART_INSTALL}/bin/oathkeeper
     source: https://github.com/ory/oathkeeper
     source-type: git
     source-tag: v0.40.3


### PR DESCRIPTION
### Context

The built `oathkeeper` binary in the ROCK image needs to align versioning with the upstream. Currently, the binary lacks the version, the corresponding commit hash, and the build time. We would like to add such information to the built binary so that users of the `oathkeeper` operator could expect the same experience as they would when using the upstream binary.

### Testing Locally

- Build the ROCK image with `rockcraft pack -v`
- Follow the instruction [HERE](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/tutorials/hello-world.html#run-the-rock-in-docker) to run with Docker with `docker run --rm --name oathkeeper <image name>:<image tag> exec oathkeeper version`