### PR TITLE
chore: update rockcraft image and fix publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install skopeo
         run: |
-          sudo snap install --devmode --channel edge skopeo
+          sudo snap install --classic --channel latest/edge rockcraft
 
       - name: Install yq
         run: |
@@ -35,7 +35,7 @@ jobs:
           image_name="$(yq '.name' rockcraft.yaml)"
           version="$(yq '.version' rockcraft.yaml)"
           rock_file=$(ls *.rock | tail -n 1)
-          sudo skopeo \
+          sudo rockcraft.skopeo \
             --insecure-policy \
             copy \
             oci-archive:"${rock_file}" \

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: oathkeeper
 base: bare
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 version: "0.40.6"
 summary: Ory Oathkeeper
 description: |
@@ -25,9 +25,9 @@ parts:
   oathkeeper:
     plugin: go
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: "0"
     override-build: |
       src_config_path="github.com/ory/oathkeeper"
       build_ver="${src_config_path}/x.Version"


### PR DESCRIPTION
This PR:
- adds the `dash` and `coreutils` packages required by COS integration
- fixes the publish workflow