### PR TITLE
feat: add arm64 architecture support

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -9,6 +9,7 @@ license: Apache-2.0
 run-user: _daemon_
 platforms:
   amd64:
+  arm64:
 
 services:
   oathkeeper:
@@ -17,17 +18,15 @@ services:
     startup: enabled
 
 parts:
-  certificates:
-    plugin: nil
-    stage-packages:
-      - ca-certificates
-
   oathkeeper:
     plugin: go
     build-snaps:
       - go/1.26/stable
     build-environment:
       - CGO_ENABLED: "0"
+    stage-packages:
+      - ca-certificates_data
+      - base-files_chisel
     override-build: |
       src_config_path="github.com/ory/oathkeeper"
       build_ver="${src_config_path}/x.Version"
@@ -57,9 +56,16 @@ parts:
       go mod edit -replace google.golang.org/grpc=google.golang.org/grpc@v1.58.3
       go mod edit -replace google.golang.org/protobuf=google.golang.org/protobuf@v1.33.0
 
-      go mod download
       go mod tidy
-      go build -ldflags="${go_linker_flags}" -o ${CRAFT_PART_INSTALL}/bin/oathkeeper
+      go mod download
+      GOARCH="${CRAFT_ARCH_BUILD_FOR}" go build -ldflags="${go_linker_flags}" -o "${CRAFT_PART_INSTALL}"/bin/oathkeeper
     source: https://github.com/ory/oathkeeper
     source-tag: v0.40.6
     source-type: git
+
+  deb-security-manifest:
+    plugin: make
+    source: https://github.com/canonical/rocks-security-manifest
+    source-type: git
+    source-branch: main
+    override-prime: gen_manifest

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -28,6 +28,9 @@ parts:
       - ca-certificates_data
       - base-files_chisel
     override-build: |
+      export PATH=/snap/bin:$PATH
+      echo "Go version used: $(go version)"
+
       src_config_path="github.com/ory/oathkeeper"
       build_ver="${src_config_path}/x.Version"
       build_hash="${src_config_path}/x.Commit"
@@ -38,6 +41,7 @@ parts:
                        -X ${build_hash}=$(git -C "${CRAFT_PART_SRC}" rev-parse HEAD) \
                        -X ${build_date}=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+      go mod edit -go=1.26
       go mod edit -replace github.com/docker/docker=github.com/docker/docker@v24.0.9+incompatible
       go mod edit -replace github.com/golang-jwt/jwt/v4=github.com/golang-jwt/jwt/v4@v4.5.2
       go mod edit -replace github.com/golang/glog=github.com/golang/glog@v1.2.4


### PR DESCRIPTION
## Description
- Added `arm64` platform support to `platforms` in `rockcraft.yaml`.
- Added `GOARCH="${CRAFT_ARCH_BUILD_FOR}"` build parameter for multi-arch compatibility.
- Updated base chisel packages and added `deb-security-manifest` part.

## Validation
- Ran `rockcraft pack` locally (amd64) -> succeeded cleanly.
- CI architecture parser extracts `["amd64", "arm64"]` and triggers matrix builds on both runners.